### PR TITLE
BUGFIX Persist data using the  `shelve` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This tool requires an API key from Yahoo. See instructions [here.](https://yahoo
 The doubleheader system is is an alternative scoring system for fantasy 
 football. See details [here.](https://www.theringer.com/nfl/2019/8/6/20755201/fantasy-football-league-settings-improvement-ideas)
 
+
+
+
 To get alternative standings under the doubleheader system: 
 
 ``` 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ football. See details [here.](https://www.theringer.com/nfl/2019/8/6/20755201/fa
 
 
 
+
+
 To get alternative standings under the doubleheader system: 
 
 ``` 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## Installation
 
+This tool depends on [yahoo-fantasy-api 2.0.1](https://pypi.org/project/yahoo-fantasy-api/2.0.1/). Note that `yahoo-fantasy-api 2.0.1` only retrives the 
+current week's fantasy data.  Data is persisted using the Python Standard Library [shelve](https://docs.python.org/3/library/shelve.html) module. 
+
+
 ```
 pip install -r requirements.txt
 pip install . 
@@ -15,17 +19,18 @@ This tool requires an API key from Yahoo. See instructions [here.](https://yahoo
 The doubleheader system is is an alternative scoring system for fantasy 
 football. See details [here.](https://www.theringer.com/nfl/2019/8/6/20755201/fantasy-football-league-settings-improvement-ideas)
 
-
-
-
-
-
-To get alternative standings under the doubleheader system: 
+After each week of games (e.g. on a Tuesday), persist the week's data and get alternative standings with: 
 
 ``` 
-python doubleheader.py -league_id <League ID>
+python doubleheader.py -league_id <League ID> --shelf
 ```
 
 League IDs can be found using the API: [`yahoo_fantasy_api.game.Game.league_ids`](https://yahoo-fantasy-api.readthedocs.io/en/latest/yahoo_fantasy_api.html#yahoo_fantasy_api.game.Game.league_ids).
 
 See an example of using `yahoo_fantasy_api.game.Game.league_ids` [here.](https://pypi.org/project/yahoo-fantasy-api/)
+
+
+## Development 
+
+PRs will trigger a Github Actions workflow. The workflow file can be found [here](https://github.com/sahildshah1/yahoo-fantasy-tools/tree/master/.github/workflows)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,5 @@ typed-ast==1.4.1
 urllib3==1.25.9
 wcwidth==0.2.5
 yahoo-fantasy-api==2.0.1
--e git+git@github.com:sahildshah1/yahoo-fantasy-tools.git@625262f8cf61463898621b0abf3457b6eb43f51e#egg=yahoo_fantasy_tools
 yahoo-oauth==1.0
 zipp==3.1.0

--- a/yahoo_fantasy_tools/doubleheader.py
+++ b/yahoo_fantasy_tools/doubleheader.py
@@ -30,7 +30,7 @@ def get_alternative_standings(lg):
     standings = get_current_standings(lg)
     bonus_wins = get_bonus_wins()
 
-    # Add team names to data frame 
+    # Add team names to data frame
     teams = lg.teams()
 
     df = pd.DataFrame(
@@ -38,16 +38,15 @@ def get_alternative_standings(lg):
             "team_key": list(standings.keys()),
             "team_name": [teams[key]["name"] for key in standings.keys()],
             "wins": [int(val["wins"]) for val in standings.values()],
-            "bonus_wins": [bonus_wins[key] for key in standings.keys()]
+            "bonus_wins": [bonus_wins[key] for key in standings.keys()],
         }
     )
 
-    df["total_wins"] = (df["wins"] + df["bonus_wins"])
+    df["total_wins"] = df["wins"] + df["bonus_wins"]
     df["ties"] = [int(val["ties"]) for val in standings.values()]
 
-    df = df.sort_values(by=['total_wins'], ascending=False, ignore_index = True)
+    df = df.sort_values(by=["total_wins"], ascending=False, ignore_index=True)
 
-    
     return df
 
 
@@ -80,10 +79,10 @@ def get_bonus_wins():
 
     """
 
-    with shelve.open('fantasy_points') as db:
+    with shelve.open("fantasy_points") as db:
         top_half_teams = [get_top_half_teams(db[key]) for key in db]
 
-    # Flatten list of sets 
+    # Flatten list of sets
     top_half_teams = list(itertools.chain(*top_half_teams))
 
     return Counter(top_half_teams)
@@ -159,12 +158,12 @@ def main(league_id, shelf):
     print(f"It's Week {lg.current_week()}!")
 
     # yahoo_fantasy_api.League.matchups only returns current week's data
-    if shelf: 
-        with shelve.open('fantasy_points') as db:
+    if shelf:
+        with shelve.open("fantasy_points") as db:
             db[str(lg.current_week())] = get_current_points(lg)
 
-
     print(get_alternative_standings(lg))
+
 
 if __name__ == "__main__":
     main()

--- a/yahoo_fantasy_tools/doubleheader.py
+++ b/yahoo_fantasy_tools/doubleheader.py
@@ -27,7 +27,8 @@ def get_alternative_standings(lg):
 
     standings = get_current_standings(lg)
 
-    doubleheader_bonus = get_doubleheader_bonus(lg)
+    # Add win if in top half of league and loss if in bottom half
+    top_half_teams = get_top_half_teams(lg)
 
     tms = lg.teams()
 
@@ -79,37 +80,6 @@ def get_current_standings(lg):
     standings = lg.standings()
 
     return {team["team_key"]: team["outcome_totals"] for team in standings}
-
-
-def get_doubleheader_bonus(lg):
-    """ Get doubleheader bonus 
-
-    Parameters
-    ----------
-    lg : yahoo_fantasy_api.League
-        An instance of the yahoo_fantasy_api League class
-
-    Returns
-    -------
-    dict 
-
-    """
-
-
-    with open('data.pickle', 'rb') as f:
-        doubleheader_bonus = pickle.load(f)
-
-
-    top_half_teams = get_top_half_teams(lg)
-
-    doubleheader_bonus = {key: val  + 1 if key in top_half_teams else val 
-                         for key, val in doubleheader_bonus.items()}
-
-    with open('data.pickle', 'wb') as f:
-        pickle.dump(doubleheader_bonus, f,  protocol=4)
-
-
-    return doubleheader_bonus
 
 
 def get_top_half_teams(lg):
@@ -182,21 +152,21 @@ def main(league_id):
 
     print(f"It's Week {lg.current_week()}!")
 
-    # yahoo_fantasy_api.League.matchups only returns current week's data
-    with shelve.open('filename') as db:
-        db[str(lg.current_week())] = get_current_points(lg)
+    # # yahoo_fantasy_api.League.matchups only returns current week's data
+    # with shelve.open('filename') as db:
+    #     db[str(lg.current_week())] = get_current_points(lg)
 
 
 
-    #Loop over points in db, compute top half teams each week update doubleheader win and loss in pandas 
+    # #Loop over points in db, compute top half teams each week update doubleheader win and loss in pandas 
 
 
-    with shelve.open('filename') as db:
-       for foo in db 
+    # with shelve.open('filename') as db:
+    #    for foo in db 
 
-            top_half_teams
+    #         top_half_teams
 
-            double_header_bonus= +1 if in top half teams 
+    #         double_header_bonus= +1 if in top half teams 
 
 
 

--- a/yahoo_fantasy_tools/doubleheader.py
+++ b/yahoo_fantasy_tools/doubleheader.py
@@ -3,6 +3,7 @@ Compute  "doubleheader" standings for the current week of the season
 """
 
 import statistics
+import shelve
 
 import pandas as pd
 import click
@@ -26,10 +27,12 @@ def get_alternative_standings(lg):
 
     standings = get_current_standings(lg)
 
-    # Add win if in top half of league and loss if in bottom half
-    top_half_teams = get_top_half_teams(lg)
+    doubleheader_bonus = get_doubleheader_bonus(lg)
 
     tms = lg.teams()
+
+
+    # Add win if in top half of league and loss if in bottom half
 
     df = pd.DataFrame(
         {
@@ -76,6 +79,37 @@ def get_current_standings(lg):
     standings = lg.standings()
 
     return {team["team_key"]: team["outcome_totals"] for team in standings}
+
+
+def get_doubleheader_bonus(lg):
+    """ Get doubleheader bonus 
+
+    Parameters
+    ----------
+    lg : yahoo_fantasy_api.League
+        An instance of the yahoo_fantasy_api League class
+
+    Returns
+    -------
+    dict 
+
+    """
+
+
+    with open('data.pickle', 'rb') as f:
+        doubleheader_bonus = pickle.load(f)
+
+
+    top_half_teams = get_top_half_teams(lg)
+
+    doubleheader_bonus = {key: val  + 1 if key in top_half_teams else val 
+                         for key, val in doubleheader_bonus.items()}
+
+    with open('data.pickle', 'wb') as f:
+        pickle.dump(doubleheader_bonus, f,  protocol=4)
+
+
+    return doubleheader_bonus
 
 
 def get_top_half_teams(lg):
@@ -146,7 +180,25 @@ def main(league_id):
     gm = yfa.Game(sc, "nfl")
     lg = gm.to_league(league_id)
 
-    print(f"The current week is {lg.current_week()}")
+    print(f"It's Week {lg.current_week()}!")
+
+    # yahoo_fantasy_api.League.matchups only returns current week's data
+    with shelve.open('filename') as db:
+        db[str(lg.current_week())] = get_current_points(lg)
+
+
+
+    #Loop over points in db, compute top half teams each week update doubleheader win and loss in pandas 
+
+
+    with shelve.open('filename') as db:
+       for foo in db 
+
+            top_half_teams
+
+            double_header_bonus= +1 if in top half teams 
+
+
 
     print(get_alternative_standings(lg))
 

--- a/yahoo_fantasy_tools/tests/test_doubleheader.py
+++ b/yahoo_fantasy_tools/tests/test_doubleheader.py
@@ -27,6 +27,22 @@ TOP_HALF_TEAMS = {
     "380.l.765649.t.7",
 }
 
+
+DOUBLEHEADER_BOUNUS = {
+
+    "380.l.765649.t.1": 0,
+    "380.l.765649.t.3": 0,
+    "380.l.765649.t.4": 0,
+    "380.l.765649.t.10": 1,
+    "380.l.765649.t.5": 1,
+    "380.l.765649.t.8": 0,
+    "380.l.765649.t.6": 1,
+    "380.l.765649.t.7": 1,
+
+}
+
+
+
 OUTCOMES = {
     "380.l.765649.t.10": {"wins": "10", "losses": "4", "ties": 0, "percentage": ".714"},
     "380.l.765649.t.4": {"wins": "7", "losses": "7", "ties": 0, "percentage": ".500"},
@@ -127,6 +143,24 @@ def test_get_current_standings():
     expected = OUTCOMES
 
     assert expected == actual
+
+
+def test_get_doubleheader_bonus():
+    """Ensure get_doubleheader_bonus returns correct answer
+    """
+
+    m_lg = mock.Mock()
+
+
+
+    actual = doubleheader.get_doubleheader_bonus(m_lg)
+
+    expected = 
+
+    assert expected = actual 
+
+
+
 
 
 @mock.patch("yahoo_fantasy_tools.doubleheader.get_current_points")

--- a/yahoo_fantasy_tools/tests/test_doubleheader.py
+++ b/yahoo_fantasy_tools/tests/test_doubleheader.py
@@ -48,40 +48,52 @@ OUTCOMES = {
 def test_get_alternative_standings(m_get_bonus_wins, m_get_current_standings):
 
     m_get_current_standings.return_value = OUTCOMES
-    m_get_bonus_wins.return_value = Counter({'380.l.765649.t.6': 2,
-                                             '380.l.765649.t.5': 2,
-                                             '380.l.765649.t.7': 2,
-                                             '380.l.765649.t.10': 2})
+    m_get_bonus_wins.return_value = Counter(
+        {
+            "380.l.765649.t.6": 2,
+            "380.l.765649.t.5": 2,
+            "380.l.765649.t.7": 2,
+            "380.l.765649.t.10": 2,
+        }
+    )
 
     m_lg = mock.Mock()
     m_lg.teams.return_value = TEAMS
 
     actual = doubleheader.get_alternative_standings(m_lg)
 
-    expected = pd.DataFrame({'team_key': ['380.l.765649.t.6',
-  '380.l.765649.t.10',
-  '380.l.765649.t.7',
-  '380.l.765649.t.5',
-  '380.l.765649.t.4',
-  '380.l.765649.t.1',
-  '380.l.765649.t.8',
-  '380.l.765649.t.3',
-  '380.l.765649.t.9',
-  '380.l.765649.t.2'],
- 'team_name': ['Shady',
-  'Easy Drake oven',
-  'Comeback Train',
-  'BetterGoEatSome Soup',
-  'The Gurley Show',
-  '...brown do for you',
-  "Sy's Slam-Dunk Team",
-  'Yolo swag 420 dab',
-  'Elementary Watson!',
-  'Goal #1 Draft Pick'],
- 'wins': [12, 10, 7, 7, 7, 7, 6, 6, 4, 4],
- 'bonus_wins': [2, 2, 2, 2, 0, 0, 0, 0, 0, 0],
- 'total_wins': [14, 12, 9, 9, 7, 7, 6, 6, 4, 4],
- 'ties': [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]})
+    expected = pd.DataFrame(
+        {
+            "team_key": [
+                "380.l.765649.t.6",
+                "380.l.765649.t.10",
+                "380.l.765649.t.7",
+                "380.l.765649.t.5",
+                "380.l.765649.t.4",
+                "380.l.765649.t.1",
+                "380.l.765649.t.8",
+                "380.l.765649.t.3",
+                "380.l.765649.t.9",
+                "380.l.765649.t.2",
+            ],
+            "team_name": [
+                "Shady",
+                "Easy Drake oven",
+                "Comeback Train",
+                "BetterGoEatSome Soup",
+                "The Gurley Show",
+                "...brown do for you",
+                "Sy's Slam-Dunk Team",
+                "Yolo swag 420 dab",
+                "Elementary Watson!",
+                "Goal #1 Draft Pick",
+            ],
+            "wins": [12, 10, 7, 7, 7, 7, 6, 6, 4, 4],
+            "bonus_wins": [2, 2, 2, 2, 0, 0, 0, 0, 0, 0],
+            "total_wins": [14, 12, 9, 9, 7, 7, 6, 6, 4, 4],
+            "ties": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        }
+    )
 
     pd.testing.assert_frame_equal(expected, actual)
 
@@ -110,12 +122,16 @@ def test_get_bonus_wins(m_open):
 
     actual = doubleheader.get_bonus_wins()
 
-    expected = Counter({'380.l.765649.t.6': 2,
-                        '380.l.765649.t.5': 2,
-                        '380.l.765649.t.7': 2,
-                        '380.l.765649.t.10': 2})
+    expected = Counter(
+        {
+            "380.l.765649.t.6": 2,
+            "380.l.765649.t.5": 2,
+            "380.l.765649.t.7": 2,
+            "380.l.765649.t.10": 2,
+        }
+    )
 
-    assert expected == actual 
+    assert expected == actual
 
 
 def test_get_top_half_teams():

--- a/yahoo_fantasy_tools/tests/test_doubleheader.py
+++ b/yahoo_fantasy_tools/tests/test_doubleheader.py
@@ -28,21 +28,6 @@ TOP_HALF_TEAMS = {
 }
 
 
-DOUBLEHEADER_BOUNUS = {
-
-    "380.l.765649.t.1": 0,
-    "380.l.765649.t.3": 0,
-    "380.l.765649.t.4": 0,
-    "380.l.765649.t.10": 1,
-    "380.l.765649.t.5": 1,
-    "380.l.765649.t.8": 0,
-    "380.l.765649.t.6": 1,
-    "380.l.765649.t.7": 1,
-
-}
-
-
-
 OUTCOMES = {
     "380.l.765649.t.10": {"wins": "10", "losses": "4", "ties": 0, "percentage": ".714"},
     "380.l.765649.t.4": {"wins": "7", "losses": "7", "ties": 0, "percentage": ".500"},
@@ -143,23 +128,6 @@ def test_get_current_standings():
     expected = OUTCOMES
 
     assert expected == actual
-
-
-def test_get_doubleheader_bonus():
-    """Ensure get_doubleheader_bonus returns correct answer
-    """
-
-    m_lg = mock.Mock()
-
-
-
-    actual = doubleheader.get_doubleheader_bonus(m_lg)
-
-    expected = 
-
-    assert expected = actual 
-
-
 
 
 


### PR DESCRIPTION
 `yahoo-fantasy-api 2.0.1` only retrieves the current week's fantasy data. 

This PR: 
-  Persists data using the `shelve` module: https://docs.python.org/3/library/shelve.html